### PR TITLE
fix: check-in, treatment queue, and checkup module

### DIFF
--- a/docs/checkin_treatment_checkup_fixes.md
+++ b/docs/checkin_treatment_checkup_fixes.md
@@ -1,0 +1,63 @@
+# Check-in / Treatment Queue / Checkup — Quick Fix
+
+Date: 2025-08-26
+
+Purpose: minimal, step-by-step fixes for check-in → treatment → checkup failures.
+
+## Symptoms
+
+- Check-in button: duplicate confirms or no action
+- Send-to-Treatment: UI shows in-treatment but no DB row
+- Missing ongoing sessions in treatment queue
+
+## Root causes
+
+- View: inline/global JS caused double confirms and inconsistent AJAX
+- Controllers: direct inserts used fields outside model `allowedFields`
+- TreatmentQueue: unconditional dentist filter hid records
+- Endpoints: non-JSON responses broke fetch-based clients
+
+## Fix steps (exact files)
+
+1. `app/Views/checkin/dashboard.php`
+   - Add `class="checkin-form"` and `class="send-to-treatment"` to forms
+   - Add `data-patient-name="..."` to forms/buttons
+   - Remove inline `onclick` confirms
+   - Add scoped JS: confirm(name) → fetch(form.action, { method:'POST', body:new FormData(form), headers:{'X-Requested-With':'XMLHttpRequest'}, credentials:'same-origin' })
+   - Show toast on JSON { success:true/false }; fallback to `form.submit()` on non-JSON
+
+2. `app/Controllers/PatientCheckin.php`
+   - Replace raw insert with `PatientCheckinModel::checkInPatient($appointmentId, $userId, ...)`
+   - Return JSON on AJAX: `{ success:true }` or `{ success:false, error:'...' }` with proper HTTP status
+   - Log model validation errors when insert fails
+
+3. `app/Controllers/TreatmentQueue.php`
+   - Replace raw insert with `TreatmentSessionModel::startSession($appointmentId, $callerId, $dentistId, ...)`
+   - Update `appointments.status` -> 'ongoing' inside DB transaction
+   - Return JSON on AJAX success/error; log model errors
+   - Apply `dentist_id` filter only when current user role is dentist
+
+4. `app/Models/PatientCheckinModel.php` and `app/Models/TreatmentSessionModel.php`
+   - Ensure `allowedFields` include all columns helpers write
+   - Implement/confirm `checkInPatient()` and `startSession()` helpers
+   - Surface validation errors via `$model->errors()` or logging
+
+## Verify (minimal)
+
+1. From UI: POST `/checkin/process/{id}` → JSON `{ success:true }`, DB `patient_checkins` created, `appointments.status` = 'checked_in'
+2. From UI: POST `/queue/call/{id}` → JSON `{ success:true }`, DB `treatment_sessions` created, `appointments.status` = 'ongoing'
+3. Treatment queue (admin/staff) shows ongoing sessions
+
+## Logs to check
+
+- `PatientCheckin insert failed. Model errors:`
+- `TreatmentSession insert failed. Model errors:`
+- `Check-in failed:`
+- `Exception calling patient:`
+
+## Follow-ups
+
+- Add PHPUnit test for check-in → send-to-treatment (happy path + validation fail)
+- Add small API response trait for consistent JSON
+
+Document: `docs/checkin_treatment_checkup_fixes.md`

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -685,6 +685,10 @@ video {
   right: 0.5rem;
 }
 
+.right-3 {
+  right: 0.75rem;
+}
+
 .right-4 {
   right: 1rem;
 }
@@ -1022,10 +1026,6 @@ video {
   max-height: 16rem;
 }
 
-.max-h-80 {
-  max-height: 20rem;
-}
-
 .max-h-96 {
   max-height: 24rem;
 }
@@ -1168,10 +1168,6 @@ video {
 
 .max-w-32 {
   max-width: 8rem;
-}
-
-.max-w-3xl {
-  max-width: 48rem;
 }
 
 .max-w-4xl {
@@ -1332,6 +1328,10 @@ video {
 
 .items-center {
   align-items: center;
+}
+
+.justify-start {
+  justify-content: flex-start;
 }
 
 .justify-end {
@@ -1631,6 +1631,11 @@ video {
   border-color: rgb(156 163 175 / var(--tw-border-opacity, 1));
 }
 
+.border-gray-50 {
+  --tw-border-opacity: 1;
+  border-color: rgb(249 250 251 / var(--tw-border-opacity, 1));
+}
+
 .border-green-200 {
   --tw-border-opacity: 1;
   border-color: rgb(187 247 208 / var(--tw-border-opacity, 1));
@@ -1738,6 +1743,11 @@ video {
 .border-yellow-500 {
   --tw-border-opacity: 1;
   border-color: rgb(234 179 8 / var(--tw-border-opacity, 1));
+}
+
+.border-red-500 {
+  --tw-border-opacity: 1;
+  border-color: rgb(239 68 68 / var(--tw-border-opacity, 1));
 }
 
 .border-l-gray-400 {
@@ -1991,11 +2001,6 @@ video {
   background-color: rgb(254 249 195 / var(--tw-bg-opacity, 1));
 }
 
-.bg-yellow-200 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(254 240 138 / var(--tw-bg-opacity, 1));
-}
-
 .bg-yellow-400 {
   --tw-bg-opacity: 1;
   background-color: rgb(250 204 21 / var(--tw-bg-opacity, 1));
@@ -2014,6 +2019,11 @@ video {
 .bg-indigo-500 {
   --tw-bg-opacity: 1;
   background-color: rgb(99 102 241 / var(--tw-bg-opacity, 1));
+}
+
+.bg-yellow-200 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(254 240 138 / var(--tw-bg-opacity, 1));
 }
 
 .bg-opacity-40 {
@@ -2221,11 +2231,6 @@ video {
   padding-bottom: 3rem;
 }
 
-.py-14 {
-  padding-top: 3.5rem;
-  padding-bottom: 3.5rem;
-}
-
 .py-16 {
   padding-top: 4rem;
   padding-bottom: 4rem;
@@ -2264,6 +2269,11 @@ video {
 .py-8 {
   padding-top: 2rem;
   padding-bottom: 2rem;
+}
+
+.py-14 {
+  padding-top: 3.5rem;
+  padding-bottom: 3.5rem;
 }
 
 .pb-2 {
@@ -2842,6 +2852,10 @@ video {
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+.ease-out {
+  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
+}
+
 .placeholder\:text-gray-400::-moz-placeholder {
   --tw-text-opacity: 1;
   color: rgb(156 163 175 / var(--tw-text-opacity, 1));
@@ -2859,6 +2873,16 @@ video {
 .hover\:border-blue-500:hover {
   --tw-border-opacity: 1;
   border-color: rgb(59 130 246 / var(--tw-border-opacity, 1));
+}
+
+.hover\:border-gray-200:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
+}
+
+.hover\:border-gray-300:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(209 213 219 / var(--tw-border-opacity, 1));
 }
 
 .hover\:bg-\[\#a47be5\]:hover {
@@ -3132,6 +3156,11 @@ video {
 .hover\:text-orange-800:hover {
   --tw-text-opacity: 1;
   color: rgb(154 52 18 / var(--tw-text-opacity, 1));
+}
+
+.hover\:text-red-700:hover {
+  --tw-text-opacity: 1;
+  color: rgb(185 28 28 / var(--tw-text-opacity, 1));
 }
 
 .hover\:text-red-900:hover {


### PR DESCRIPTION
- Fixed check-in button (removed duplicate confirms, added AJAX, toast feedback)
- Fixed send-to-treatment (ensured DB row creation, proper status update)
- Used model helpers (checkInPatient, startSession) to respect allowedFields/validation
- Returned structured JSON for AJAX endpoints, added error logging
- Fixed treatment queue filtering (dentist filter only for dentist users)
- Added concise quick-fix guide for future devs in docs/checkin_treatment_checkup_fixes.md